### PR TITLE
Add source browser module with dataset

### DIFF
--- a/app/data/atomic_bomb_sources_dataset.json
+++ b/app/data/atomic_bomb_sources_dataset.json
@@ -1,0 +1,142 @@
+[
+  {
+    "id": "truman_statement",
+    "title": "Statement by President Truman Announcing the Use of the Bomb on Hiroshima",
+    "author": "Harry S. Truman",
+    "date": "1945-08-06",
+    "type": "Primary Source",
+    "perspective": "Justified",
+    "who": "President Harry S. Truman",
+    "why": "Believed the bomb was necessary to end the war quickly and avoid further American casualties.",
+    "link": "https://www.trumanlibrary.gov/library/public-papers/93/",
+    "citation": {
+      "mla": "Truman, Harry S. \"Statement by the President Announcing the Use of the Bomb on Hiroshima.\" 6 Aug. 1945. Truman Library, https://www.trumanlibrary.gov/library/public-papers/93/."
+    }
+  },
+  {
+    "id": "szilard_petition",
+    "title": "Petition to the President of the United States",
+    "author": "Leo Szilard and 69 Manhattan Project Scientists",
+    "date": "1945-07-17",
+    "type": "Primary Source",
+    "perspective": "Unjustified",
+    "who": "Leo Szilard and other Manhattan Project scientists",
+    "why": "Urged reconsideration of the bomb use due to moral and global consequences.",
+    "link": "https://ahf.nuclearmuseum.org/ahf/key-documents/szilard-petition/",
+    "citation": {
+      "mla": "Szilard, Leo. \"Petition to the President of the United States.\" 17 July 1945, Atomic Heritage Foundation, https://ahf.nuclearmuseum.org/ahf/key-documents/szilard-petition/."
+    }
+  },
+  {
+    "id": "franck_report",
+    "title": "The Franck Report",
+    "author": "James Franck and Committee of Scientists",
+    "date": "1945-06-11",
+    "type": "Primary Source",
+    "perspective": "Complex",
+    "who": "James Franck and Manhattan Project scientists",
+    "why": "Recommended a demonstration of the bomb before using it on civilians.",
+    "link": "https://fissilematerials.org/library/fra45.pdf",
+    "citation": {
+      "mla": "Franck, James, et al. \"The Franck Report.\" 11 June 1945, https://fissilematerials.org/library/fra45.pdf."
+    }
+  },
+  {
+    "id": "eisenhower_reflection",
+    "title": "Eisenhower Reflects on the Bombing Decision",
+    "author": "Dwight D. Eisenhower",
+    "date": "1963",
+    "type": "Secondary Source",
+    "perspective": "Unjustified",
+    "who": "General Dwight D. Eisenhower",
+    "why": "Believed Japan was close to surrender and the bomb was unnecessary.",
+    "link": "https://www.raabcollection.com/presidential-autographs/eisenhower-nuclear",
+    "citation": {
+      "mla": "Eisenhower, Dwight D. \"Eisenhower Reflects on the Bombing Decision.\" The Raab Collection, https://www.raabcollection.com/presidential-autographs/eisenhower-nuclear."
+    }
+  },
+  {
+    "id": "alperovitz_analysis",
+    "title": "Why the U.S. Really Bombed Hiroshima",
+    "author": "Gar Alperovitz",
+    "date": "2015",
+    "type": "Secondary Source",
+    "perspective": "Complex",
+    "who": "Historian Gar Alperovitz",
+    "why": "Argued the bomb's use was politically motivated and alternatives were ignored.",
+    "link": "https://www.thenation.com/article/world/why-the-us-really-bombed-hiroshima/",
+    "citation": {
+      "mla": "Alperovitz, Gar. \"Why the U.S. Really Bombed Hiroshima.\" The Nation, July 2015, https://www.thenation.com/article/world/why-the-us-really-bombed-hiroshima/."
+    }
+  },
+  {
+    "id": "hiroshima_diary",
+    "title": "Hiroshima",
+    "author": "John Hersey",
+    "date": "1946",
+    "type": "Primary Source",
+    "perspective": "Unjustified",
+    "who": "Japanese civilians and survivors",
+    "why": "Recounts the devastating human impact on civilians in Hiroshima.",
+    "link": "https://www.newyorker.com/magazine/1946/08/31/hiroshima",
+    "citation": {
+      "mla": "Hersey, John. \"Hiroshima.\" The New Yorker, 31 Aug. 1946, https://www.newyorker.com/magazine/1946/08/31/hiroshima."
+    }
+  },
+  {
+    "id": "churchill_memoirs",
+    "title": "Triumph and Tragedy",
+    "author": "Winston S. Churchill",
+    "date": "1953",
+    "type": "Secondary Source",
+    "perspective": "Justified",
+    "who": "Prime Minister Winston Churchill",
+    "why": "Supported the use of overwhelming force to end the war and avoid Soviet occupation of Japan.",
+    "link": "https://archive.org/details/TheSecondWorldWarChurchill/mode/2up",
+    "citation": {
+      "mla": "Churchill, Winston S. *Triumph and Tragedy*. Houghton Mifflin, 1953."
+    }
+  },
+  {
+    "id": "stimson_memo",
+    "title": "Stimson’s Memo to Truman on Use of the Bomb",
+    "author": "Henry L. Stimson",
+    "date": "1945-09-11",
+    "type": "Primary Source",
+    "perspective": "Justified",
+    "who": "Secretary of War Henry Stimson",
+    "why": "Outlined the rationale for using the atomic bomb to bring the war to a swift end.",
+    "link": "https://www.trumanlibrary.gov/library/online-collections/decision-to-drop-atomic-bomb",
+    "citation": {
+      "mla": "Stimson, Henry L. \"Memorandum to President Truman.\" 11 Sept. 1945, Harry S. Truman Library, https://www.trumanlibrary.gov/library/online-collections/decision-to-drop-atomic-bomb."
+    }
+  },
+  {
+    "id": "operation_downfall",
+    "title": "Operation Downfall",
+    "author": "U.S. Joint Chiefs of Staff",
+    "date": "1945",
+    "type": "Secondary Source",
+    "perspective": "Justified",
+    "who": "U.S. Military Planners",
+    "why": "Estimated massive Allied and Japanese casualties in a land invasion.",
+    "link": "https://www.history.navy.mil/about-us/leadership/director/directors-corner/h-grams/h-gram-057/h-057-1.html",
+    "citation": {
+      "mla": "U.S. Joint Chiefs of Staff. \"Operation Downfall: The Planned Invasion of Japan.\" U.S. Naval History and Heritage Command, https://www.history.navy.mil/about-us/leadership/director/directors-corner/h-grams/h-gram-057/h-057-1.html."
+    }
+  },
+  {
+    "id": "interim_committee_minutes",
+    "title": "Minutes of the Interim Committee Meeting",
+    "author": "Interim Committee",
+    "date": "1945-05-31",
+    "type": "Primary Source",
+    "perspective": "Complex",
+    "who": "Advisory group to President Truman",
+    "why": "Discussed the use of the bomb and rejected the idea of a demonstration strike.",
+    "link": "https://www.atomicarchive.com/resources/documents/manhattan-project/interim-committee.html",
+    "citation": {
+      "mla": "Interim Committee. \"Meeting Minutes.\" 31 May 1945, Atomic Archive, https://www.atomicarchive.com/resources/documents/manhattan-project/interim-committee.html."
+    }
+  }
+]

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,18 @@
+import "../globals.css";
+import { ReactNode } from "react";
+import { SelectedSourcesProvider } from "./sources/useSelectedSources";
+import { FilterProvider } from "../components/filterStore";
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <FilterProvider>
+          <SelectedSourcesProvider>
+            {children}
+          </SelectedSourcesProvider>
+        </FilterProvider>
+      </body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,8 @@
+export default function Home() {
+  return (
+    <main>
+      <h1>Atomic Choices</h1>
+      <p>Select "Sources" in the URL to view the browser.</p>
+    </main>
+  );
+}

--- a/app/sources/SourceCard.tsx
+++ b/app/sources/SourceCard.tsx
@@ -1,0 +1,39 @@
+'use client';
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Accordion, AccordionItem, AccordionTrigger, AccordionContent } from "@/components/ui/accordion";
+import { Source } from './SourceList';
+import useSelectedSources from './useSelectedSources';
+
+export default function SourceCard({ source }: { source: Source }) {
+  const { selected, toggleSource } = useSelectedSources();
+  const isSelected = selected.some((s) => s.id === source.id);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{source.title}</CardTitle>
+        <div className="flex items-center gap-2 text-sm">
+          <span>{source.author}</span>
+          <Badge variant="secondary">{source.type}</Badge>
+          <Badge>{source.perspective}</Badge>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <Button variant={isSelected ? 'destructive' : 'default'} onClick={() => toggleSource(source)}>
+          {isSelected ? 'Remove' : 'Add to Outline'}
+        </Button>
+        <Accordion type="single" collapsible>
+          <AccordionItem value="info">
+            <AccordionTrigger>Details</AccordionTrigger>
+            <AccordionContent>
+              <p className="text-sm mb-2">{source.why}</p>
+              <p className="text-xs italic">{source.citation.mla}</p>
+            </AccordionContent>
+          </AccordionItem>
+        </Accordion>
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/sources/SourceList.tsx
+++ b/app/sources/SourceList.tsx
@@ -1,0 +1,38 @@
+'use client';
+import sourcesData from '../data/atomic_bomb_sources_dataset.json';
+import SourceCard from './SourceCard';
+import useFilterStore from '../../components/filterStore';
+
+export interface Source {
+  id: string;
+  title: string;
+  author: string;
+  date: string;
+  type: string;
+  perspective: string;
+  who: string;
+  why: string;
+  link: string;
+  citation: {
+    mla: string;
+  };
+}
+
+const allSources: Source[] = sourcesData as Source[];
+
+export default function SourceList() {
+  const { perspective, types } = useFilterStore();
+  const filtered = allSources.filter((s) => {
+    const pMatch = perspective.length === 0 || perspective.includes(s.perspective);
+    const tMatch = types.length === 0 || types.includes(s.type);
+    return pMatch && tMatch;
+  });
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      {filtered.map((source) => (
+        <SourceCard key={source.id} source={source} />
+      ))}
+    </div>
+  );
+}

--- a/app/sources/page.tsx
+++ b/app/sources/page.tsx
@@ -1,0 +1,13 @@
+import SourceList from "./SourceList";
+import SelectedSourcesPanel from "../../components/SelectedSourcesPanel";
+import FilterControls from "../../components/FilterControls";
+
+export default function SourcesPage() {
+  return (
+    <div className="space-y-4">
+      <FilterControls />
+      <SourceList />
+      <SelectedSourcesPanel />
+    </div>
+  );
+}

--- a/app/sources/useSelectedSources.ts
+++ b/app/sources/useSelectedSources.ts
@@ -1,0 +1,44 @@
+'use client';
+import { createContext, useContext, useState } from 'react';
+import { Source } from './SourceList';
+import { useToast } from '@/components/ui/use-toast';
+
+interface Context {
+  selected: Source[];
+  toggleSource: (source: Source) => void;
+  clear: () => void;
+}
+
+const SelectedSourcesContext = createContext<Context | null>(null);
+
+export function SelectedSourcesProvider({ children }: { children: React.ReactNode }) {
+  const [selected, setSelected] = useState<Source[]>([]);
+  const { toast } = useToast();
+
+  const toggleSource = (source: Source) => {
+    const exists = selected.some((s) => s.id === source.id);
+    if (exists) {
+      setSelected(selected.filter((s) => s.id !== source.id));
+    } else {
+      if (selected.length >= 5) {
+        toast({ title: 'You can select up to 5 sources' });
+        return;
+      }
+      setSelected([...selected, source]);
+    }
+  };
+
+  const clear = () => setSelected([]);
+
+  return (
+    <SelectedSourcesContext.Provider value={{ selected, toggleSource, clear }}>
+      {children}
+    </SelectedSourcesContext.Provider>
+  );
+}
+
+export default function useSelectedSources() {
+  const ctx = useContext(SelectedSourcesContext);
+  if (!ctx) throw new Error('useSelectedSources must be within provider');
+  return ctx;
+}

--- a/components/FilterControls.tsx
+++ b/components/FilterControls.tsx
@@ -1,0 +1,46 @@
+'use client';
+import { useState } from 'react';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Label } from '@/components/ui/label';
+import useFilterStore from './filterStore';
+
+const perspectives = ['Justified', 'Unjustified', 'Complex'];
+const types = ['Primary Source', 'Secondary Source'];
+
+export default function FilterControls() {
+  const { perspective, types: selectedTypes, setFilters } = useFilterStore();
+  const [pState, setPState] = useState<string[]>(perspective);
+  const [tState, setTState] = useState<string[]>(selectedTypes);
+
+  const toggle = (arr: string[], value: string, setter: (v: string[]) => void) => {
+    if (arr.includes(value)) {
+      setter(arr.filter((v) => v !== value));
+    } else {
+      setter([...arr, value]);
+    }
+  };
+
+  const apply = () => setFilters(pState, tState);
+
+  return (
+    <div className="space-y-2">
+      <div>
+        <p className="font-medium">Perspective</p>
+        {perspectives.map((p) => (
+          <Label key={p} className="mr-4">
+            <Checkbox checked={pState.includes(p)} onCheckedChange={() => toggle(pState, p, setPState)} /> {p}
+          </Label>
+        ))}
+      </div>
+      <div>
+        <p className="font-medium">Type</p>
+        {types.map((t) => (
+          <Label key={t} className="mr-4">
+            <Checkbox checked={tState.includes(t)} onCheckedChange={() => toggle(tState, t, setTState)} /> {t}
+          </Label>
+        ))}
+      </div>
+      <button className="px-2 py-1 bg-blue-600 text-white" onClick={apply}>Apply Filters</button>
+    </div>
+  );
+}

--- a/components/SelectedSourcesPanel.tsx
+++ b/components/SelectedSourcesPanel.tsx
@@ -1,0 +1,32 @@
+'use client';
+import useSelectedSources from '../app/sources/useSelectedSources';
+import { Button } from '@/components/ui/button';
+
+export default function SelectedSourcesPanel() {
+  const { selected, toggleSource, clear } = useSelectedSources();
+
+  const copyBibliography = () => {
+    const text = selected.map((s) => s.citation.mla).join('\n');
+    navigator.clipboard.writeText(text);
+  };
+
+  if (selected.length === 0) return null;
+
+  return (
+    <div className="border p-4 space-y-2">
+      <h2 className="font-bold">Selected Sources</h2>
+      <ul className="list-disc pl-5 space-y-1">
+        {selected.map((s) => (
+          <li key={s.id} className="flex justify-between items-start">
+            <span className="text-sm">{s.citation.mla}</span>
+            <Button variant="ghost" onClick={() => toggleSource(s)}>Remove</Button>
+          </li>
+        ))}
+      </ul>
+      <div className="flex gap-2">
+        <Button onClick={copyBibliography}>Copy MLA Bibliography</Button>
+        <Button variant="outline" onClick={clear}>Clear</Button>
+      </div>
+    </div>
+  );
+}

--- a/components/filterStore.ts
+++ b/components/filterStore.ts
@@ -1,0 +1,32 @@
+'use client';
+import { createContext, useContext, useState } from 'react';
+
+interface FilterContext {
+  perspective: string[];
+  types: string[];
+  setFilters: (p: string[], t: string[]) => void;
+}
+
+const Ctx = createContext<FilterContext | null>(null);
+
+export function FilterProvider({ children }: { children: React.ReactNode }) {
+  const [perspective, setPerspective] = useState<string[]>([]);
+  const [types, setTypes] = useState<string[]>([]);
+
+  const setFilters = (p: string[], t: string[]) => {
+    setPerspective(p);
+    setTypes(t);
+  };
+
+  return (
+    <Ctx.Provider value={{ perspective, types, setFilters }}>
+      {children}
+    </Ctx.Provider>
+  );
+}
+
+export default function useFilterStore() {
+  const ctx = useContext(Ctx);
+  if (!ctx) throw new Error('useFilterStore must be within provider');
+  return ctx;
+}

--- a/globals.css
+++ b/globals.css
@@ -1,0 +1,5 @@
+/* Tailwind base styles would be imported here */
+body {
+  font-family: sans-serif;
+  padding: 20px;
+}

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    appDir: true,
+  },
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "truman-essay-cyoa",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.0.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "typescript": "5.0.0"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  content: [
+    './app/**/*.{ts,tsx}',
+    './components/**/*.{ts,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/utils/formatCitation.ts
+++ b/utils/formatCitation.ts
@@ -1,0 +1,3 @@
+export function formatCitation(mla: string) {
+  return mla;
+}


### PR DESCRIPTION
## Summary
- add atomic bomb dataset as JSON
- implement SourceList with filtering
- create SourceCard UI component with add/remove
- manage selected sources with context provider
- add SelectedSourcesPanel and FilterControls
- configure layout with providers and minimal Next.js setup

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_6841e00a8218832bb46868a23fde9c7b